### PR TITLE
Aetherling: ValueType Containing CoreIRType and Standard CoreIR Module Importing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 build
 dist
 *.pyc
+.idea/

--- a/coreir/__init__.py
+++ b/coreir/__init__.py
@@ -154,6 +154,9 @@ libcoreir_c.COREValueBitVector.restype = COREValue_p
 libcoreir_c.COREValueModule.argtypes = [COREContext_p, COREModule_p]
 libcoreir_c.COREValueModule.restype = COREValue_p
 
+libcoreir_c.COREValueCoreIRType.argtypes = [COREContext_p, COREType_p]
+libcoreir_c.COREValueCoreIRType.restype = COREValue_p
+
 libcoreir_c.COREModuleDefGetConnections.argtypes = [COREModuleDef_p, ct.POINTER(ct.c_int)]
 libcoreir_c.COREModuleDefGetConnections.restype = ct.POINTER(COREConnection_p)
 


### PR DESCRIPTION
The __ init__.py and new_values changes enable interfacing with the CoreIR C code for getting ValueTypes containing CoreIR Types.

The new functions standardize the work in https://github.com/leonardt/pycoreir/blob/39455d1d3b5940db7040310351d1b1014844e4f3/tests/test_primitives.py#L68 for getting CoreIR C++ modules into python.

**Please wait to merge until this pull request gets approved: https://github.com/rdaly525/coreir/pull/475**