### PR TITLE
Makes LazyDict a subclass of collections.abc.Mapping

### DIFF
--- a/_python_test_output.json
+++ b/_python_test_output.json
@@ -8,7 +8,7 @@
           ["in2",["Array",8,"BitIn"]],
           ["out",["Array",9,"Bit"]]
         ]],
-        "modparams":{"init":"Int"}
+        "modparams":{"init":"Int", "test_param0":"Int", "test_param1":"Int"}
       },
       "multiply_by_2":{
         "type":["Record",[
@@ -18,7 +18,7 @@
         "instances":{
           "adder":{
             "modref":"global.add8",
-            "modargs":{"init":["Int",5]}
+            "modargs":{"init":["Int",5], "test_param0":["Int",1], "test_param1":["Int",0]}
           }
         },
         "connections":[

--- a/coreir/__init__.py
+++ b/coreir/__init__.py
@@ -124,6 +124,9 @@ libcoreir_c.COREGetModuleRef.restype = COREModule_p
 libcoreir_c.COREGetModArg.argtypes = [COREWireable_p, ct.c_char_p]
 libcoreir_c.COREGetModArg.restype = COREValue_p
 
+libcoreir_c.COREGetModArgs.argtypes = [COREWireable_p, ct.POINTER(ct.POINTER(ct.c_char_p)), ct.POINTER(ct.POINTER(COREValue_p))]
+libcoreir_c.COREGetModArgs.restype = None
+
 libcoreir_c.COREHasModArg.argtypes = [COREWireable_p, ct.c_char_p]
 libcoreir_c.COREHasModArg.restype = ct.c_bool
 
@@ -251,11 +254,17 @@ libcoreir_c.COREModuleIsGenerated.restype = ct.c_bool
 libcoreir_c.CORENamespaceGetGenerator.argtypes = [CORENamespace_p, ct.c_char_p]
 libcoreir_c.CORENamespaceGetGenerator.restype = COREGenerator_p
 
+libcoreir_c.CORENamespaceGetGenerators.argtypes = [CORENamespace_p, ct.POINTER(ct.POINTER(ct.c_char_p)), ct.POINTER(ct.POINTER(COREGenerator_p))]
+libcoreir_c.CORENamespaceGetGenerators.restype = None
+
 libcoreir_c.CORENamespaceHasGenerator.argtypes = [CORENamespace_p, ct.c_char_p]
 libcoreir_c.CORENamespaceHasGenerator.restype = ct.c_bool
 
 libcoreir_c.CORENamespaceGetModule.argtypes = [CORENamespace_p, ct.c_char_p]
 libcoreir_c.CORENamespaceGetModule.restype = COREModule_p
+
+libcoreir_c.CORENamespaceGetModules.argtypes = [CORENamespace_p, ct.POINTER(ct.POINTER(ct.c_char_p)), ct.POINTER(ct.POINTER(COREModule_p))]
+libcoreir_c.CORENamespaceGetModules.restype = None
 
 libcoreir_c.CORENamespaceHasModule.argtypes = [CORENamespace_p, ct.c_char_p]
 libcoreir_c.CORENamespaceHasModule.restype = ct.c_bool

--- a/coreir/namespace.py
+++ b/coreir/namespace.py
@@ -1,9 +1,9 @@
 import ctypes as ct
 from coreir.type import CoreIRType, Type, Params
-from coreir.module import Module
+from coreir.module import Module, COREModule_p
 from coreir.lib import libcoreir_c
 from coreir.util import LazyDict
-from coreir.generator import Generator
+from coreir.generator import Generator, COREGenerator_p
 
 class CORENamespace(ct.Structure):
     pass
@@ -14,12 +14,14 @@ CORENamespace_p = ct.POINTER(CORENamespace)
 class Namespace(CoreIRType):
     def __init__(self, ptr, context):
         super(Namespace, self).__init__(ptr, context)
-        self.generators = LazyDict(self, Generator,
+        self.generators = LazyDict(self, Generator, COREGenerator_p,
                 libcoreir_c.CORENamespaceGetGenerator,
-                libcoreir_c.CORENamespaceHasGenerator)
-        self.modules = LazyDict(self, Module,
+                libcoreir_c.CORENamespaceHasGenerator,
+                libcoreir_c.CORENamespaceGetGenerators)
+        self.modules = LazyDict(self, Module, COREModule_p,
                 libcoreir_c.CORENamespaceGetModule,
-                libcoreir_c.CORENamespaceHasModule)
+                libcoreir_c.CORENamespaceHasModule,
+                libcoreir_c.CORENamespaceGetModules)
 
     @property
     def name(self):

--- a/coreir/util.py
+++ b/coreir/util.py
@@ -1,14 +1,21 @@
-class LazyDict:
+from collections import Mapping
+import ctypes as ct
+from .lib import libcoreir_c
+
+
+class LazyDict(Mapping):
     """
     Lazy object that implements the ``dict[key]`` interface. Instead
     of building the dictionary explicitly for every call to config, we wait for
     the indexing function to be called and then use the api function
     """
-    def __init__(self, parent, return_type, get_function, has_function):
+    def __init__(self, parent, return_type, core_return_type, get_function, has_function, iter_function):
         self.parent = parent
         self.return_type = return_type
+        self.core_return_type = core_return_type
         self.get_function = get_function
         self.has_function = has_function
+        self.iter_function = iter_function
 
     def __contains__(self, key):
         return self.has_function(self.parent.ptr, str.encode(key))
@@ -20,6 +27,25 @@ class LazyDict:
                    self.get_function(self.parent.ptr,
                                      str.encode(key)),
                    self.parent.context)
+
+    def __iter__(self):
+        c_keys = ct.POINTER(ct.c_char_p)()
+        c_values = ct.POINTER(self.core_return_type)()
+        size = ct.c_int()
+        self.iter_function(self.parent.ptr, ct.byref(c_keys), ct.byref(c_values), ct.byref(size))
+        _dict = {}
+        for i in range(0, size.value):
+            _dict[c_keys[i].decode()] = self.return_type(c_values[i], self.parent.context)
+        libcoreir_c.COREFree(c_keys, c_values)
+        return iter(_dict)
+
+    def __len__(self):
+        # TODO: Should just be an API call
+        _len = 0
+        for _ in self:
+            _len += 1
+        return _len
+
 
     def __setitem__(self, key, value):
         raise NotImplementedError()

--- a/coreir/wireable.py
+++ b/coreir/wireable.py
@@ -52,8 +52,8 @@ class Select(Wireable):
 class Instance(Wireable):
     def __init__(self, ptr, context):
         super(Instance, self).__init__(ptr, context)
-        self.config = LazyDict(self, Value, libcoreir_c.COREGetModArg,
-                libcoreir_c.COREHasModArg)
+        self.config = LazyDict(self, Value, COREValue_p, libcoreir_c.COREGetModArg,
+                libcoreir_c.COREHasModArg, libcoreir_c.COREGetModArgs)
 
     @property
     def module(self):

--- a/tests/test_coreir.py
+++ b/tests/test_coreir.py
@@ -14,7 +14,7 @@ def test_save_module():
     module.print_()
     assert module.definition is None, "Should not have a definition"
     module_def = module.new_definition()
-    configparams = c.newParams({"init":c.Int()})
+    configparams = c.newParams({"init":c.Int(), "test_param0": c.Int(), "test_param1": c.Int()})
     add8 = c.global_namespace.new_module("add8",
         c.Record({
             "in1": c.Array(8, c.BitIn()),
@@ -30,10 +30,16 @@ def test_save_module():
         else:
             assert len(type_) == 9
     add8_inst = module_def.add_module_instance("adder", add8,
-            c.new_values({"init":5}))
+        c.new_values({"init":5, "test_param0": 1, "test_param1": 0}))
     assert add8_inst.module.namespace.name == "global"
     assert add8_inst.module.name == "add8"
     assert add8_inst.config["init"].value == 5
+    expected = {"init": 5, "test_param0": 1, "test_param1": 0}
+    assert len(add8_inst.config) == len(expected)
+    for key, value in add8_inst.config.items():
+        assert key in expected and expected[key] == value.value
+        del expected[key]
+    assert not expected, "Should be empty"
     add8_in1 = add8_inst.select("in1")
     add8_in2 = add8_inst.select("in2")
     add8_out = add8_inst.select("out")

--- a/tests/test_lazy_dict.py
+++ b/tests/test_lazy_dict.py
@@ -1,0 +1,16 @@
+import coreir
+
+def test_namespace():
+    context = coreir.Context()
+    coreir_namespace = context.get_namespace("coreir")
+    for name, generator in coreir_namespace.generators.items():
+        assert isinstance(name, str)
+        assert isinstance(generator, coreir.Generator)
+        print(name, generator)
+
+    ice40_library = context.load_library("ice40")
+    for name, module in ice40_library.modules.items():
+        assert isinstance(name, str), name
+        assert isinstance(module, coreir.Module), module
+        print(name, module)
+


### PR DESCRIPTION
Addresses https://github.com/leonardt/pycoreir/issues/6 by implementing `__getitem__`, `__iter__`, `__len__`

Some examples added to the tests:
```python
    expected = {"init": 5, "test_param0": 1, "test_param1": 0}
    assert len(add8_inst.config) == len(expected)
    for key, value in add8_inst.config.items():
        assert key in expected and expected[key] == value.value
        del expected[key]
    assert not expected, "Should be empty"
```

and

```python
    context = coreir.Context()
    coreir_namespace = context.get_namespace("coreir")
    for name, generator in coreir_namespace.generators.items():
        assert isinstance(name, str)
        assert isinstance(generator, coreir.Generator)
        print(name, generator)

    ice40_library = context.load_library("ice40")
    for name, module in ice40_library.modules.items():
        assert isinstance(name, str), name
        assert isinstance(module, coreir.Module), module
        print(name, module)

```

Depends on https://github.com/rdaly525/coreir/pull/508