### PR TITLE
Fixed CoreIR To PyCoreIR Type Conversion With Nesting

### DIFF
--- a/coreir/type.py
+++ b/coreir/type.py
@@ -121,7 +121,15 @@ class Record(Type):
                 ct.byref(values), ct.byref(size))
         retval = {}
         for i in range(size.value):
-            retval[keys[i].decode()] = Type(values[i], self.context)
+            uncastedType = Type(values[i], self.context)
+            if (uncastedType.kind == "Record"):
+                retval[keys[i].decode()] = Record(values[i], self.context)
+            elif (uncastedType.kind == "Named"):
+                retval[keys[i].decode()] = NamedType(values[i], self.context)
+            else:
+                # don't need to handle arrays, bit, and bitin separately as they all
+                # don't subclass the CoreIR Type class
+                retval[keys[i].decode()] = Type(values[i], self.context)
         return retval.items()
 
 

--- a/coreir/type.py
+++ b/coreir/type.py
@@ -68,9 +68,9 @@ class Values(CoreIRType):
 
 def getPyCoreIRType(ptr, context):
     kind = libcoreir_c.COREGetTypeKind(ptr)
-    if (kind == "Record"):
+    if (kind == 3):
         return Record(ptr, context)
-    elif (kind == "Named"):
+    elif (kind == 4):
         return NamedType(ptr, context)
     else:
         # don't need to handle arrays, bit, and bitin separately as they all


### PR DESCRIPTION
Previously, when getting a type contained in a record or array, you'd always get a Type object back. This prevented using record/array types that contained record types. I've fixed that so now you get a Record object back. (also added support for namedtypes but nobody uses that)