### PR TITLE
Raise exception on selection error instead of segfault

### DIFF
--- a/coreir/__init__.py
+++ b/coreir/__init__.py
@@ -202,6 +202,9 @@ libcoreir_c.COREWireableGetType.restype = COREType_p
 libcoreir_c.COREModuleDefSelect.argtypes = [COREModuleDef_p, ct.c_char_p]
 libcoreir_c.COREModuleDefSelect.restype = COREWireable_p
 
+libcoreir_c.COREModuleDefCanSelect.argtypes = [COREModuleDef_p, ct.c_char_p]
+libcoreir_c.COREModuleDefCanSelect.restype = bool
+
 libcoreir_c.COREModuleDefGetModule.argtypes = [COREModuleDef_p]
 libcoreir_c.COREModuleDefGetModule.restype = COREModule_p
 

--- a/coreir/module.py
+++ b/coreir/module.py
@@ -6,6 +6,10 @@ from coreir.wireable import Instance, Interface
 from coreir.type import COREValue_p, Value, Record
 import coreir.wireable
 
+
+class SelectError(RuntimeError):
+    pass
+
 class NotAGeneratorException(Exception):
     pass
 
@@ -70,6 +74,8 @@ class ModuleDef(CoreIRType):
         libcoreir_c.COREModuleDefConnect(self.ptr, a.ptr, b.ptr)
 
     def select(self, field):
+        if not libcoreir_c.COREModuleDefCanSelect(self.ptr, str.encode(field)):
+            raise SelectError(f"Cannot select path {field}")
         return coreir.wireable.Wireable(libcoreir_c.COREModuleDefSelect(self.ptr, str.encode(field)),self.context)
 
     def print_(self):  # _ because print is a keyword in py2
@@ -172,7 +178,7 @@ class DirectedConnection(CoreIRType):
     @property
     def size(self):
         assert self.parent.sel(self.source).type.size == self.parent.sel(self.sink).type.size
-        return self.parent.sel(self.source).type.size 
+        return self.parent.sel(self.source).type.size
 
     @property
     def source(self):


### PR DESCRIPTION
Depends on https://github.com/rdaly525/coreir/pull/598

Avoids one possible coreir assertion failure with a bad selection which kills the interpreter, instead raises an exception.