### PR TITLE
Support for Python < 3.6

### DIFF
--- a/coreir/generator.py
+++ b/coreir/generator.py
@@ -33,9 +33,9 @@ class Generator(CoreIRType):
         gen_args = {}
         for key, value in kwargs.items():
             if key not in self.params:
-                raise KeyError(f"key={key} not in params={self.params.keys()}")
+                raise KeyError("key={key} not in params={keys}".format(key=key, keys=self.params.keys()))
             if not isinstance(value, self.params[key].kind):
-                raise ValueError(f"Arg(name={key}, value={value}) does not match expected type {self.params[key].kind}")
+                raise ValueError("Arg(name={key}, value={value}) does not match expected type {kind}".format(key=key, value=value, kind=self.params[key].kind))
             gen_args[key] = value
         gen_args = self.context.new_values(gen_args)
         return Module(libcoreir_c.COREGeneratorGetModule(self.ptr, gen_args.ptr), self.context)

--- a/coreir/module.py
+++ b/coreir/module.py
@@ -75,7 +75,7 @@ class ModuleDef(CoreIRType):
 
     def select(self, field):
         if not libcoreir_c.COREModuleDefCanSelect(self.ptr, str.encode(field)):
-            raise SelectError(f"Cannot select path {field}")
+            raise SelectError("Cannot select path {field}".format(field=field))
         return coreir.wireable.Wireable(libcoreir_c.COREModuleDefSelect(self.ptr, str.encode(field)),self.context)
 
     def print_(self):  # _ because print is a keyword in py2

--- a/coreir/type.py
+++ b/coreir/type.py
@@ -124,7 +124,7 @@ class Record(Type):
         for i in range(size.value):
             if keys[i].decode() == key:
                 return Type(values[i], self.context)
-        raise KeyError(f"key={key} not found")
+        raise KeyError("key={key} not found".format(key=key))
 
     def items(self):
         keys = ct.POINTER(ct.c_char_p)()

--- a/coreir/wireable.py
+++ b/coreir/wireable.py
@@ -64,7 +64,7 @@ class Instance(Wireable):
         return coreir.module.Module(module, self.context)
 
     def __str__(self):
-        return f"{self.module.name}.{self.name}"
+        return "{modulename}.{name}".format(modulename=self.module.name, name=self.name)
 
     @property
     def name(self):


### PR DESCRIPTION
Changed string format to rely on format() instead of f-strings, this improves the compatibility with Python versions < 3.6