### PR TITLE
Add script to deploy manylinux wheel to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,21 @@ before_install:
 script:
     - docker exec manylinux pip install magma-lang  # For libcoreir-python test
     - docker exec manylinux pytest -s /pycoreir/tests/
-    # copy everything back
-    - docker exec manylinux bash -c "ls /pycoreir/wheelhouse/*.whl" > wheels
-    - while read whl; do docker cp manylinux:$whl .; done <wheels
-    - ls *.whl
 
 deploy:
-  provider: pypi
+- provider: pypi
   user: leonardt
   password:
     secure: EMYqO+p8gN4aKv6dwaF9YVoheoyYQ+DFYkrUUU7T0LF/q3E4cR514ENS92LhaaISjbecfhbinMEgPUNsswTzT9c0RCO3BsrcPEhHWSistFtXcLIbAz0gw9ARcNGs+TElA71V7gUeCPtNUD1Inw8+Dp9B7zKuUKabsOnvWQ6bCeaPiWTnAfbzXq0yK+njjEEPo510bQ4U8IR0NfJxyR/6TDPkMNsvV0M/jCJcmukNDnT2PnSpSuqNOec+5Nv4xJT1Ub2J6SPPEyG1IFWMjmd2jYlfbj8lIXFv1+FwWivAsfEsSyf3ZQyWBSlqc1Hjo8mbiu2p2nOuAj+zCDLf2ySkyXxKMPFq917osyyrohqLo6p2s6GPWCelWTywbD31ZdfpDh8f0abfEMc/d7RgVZjmzrczYny2x++asqkOnnP9paYKoydqHPeXOnSKeNsfgBVZT4JDpnp7FPtbyoPEjeQhN/+dSIoXEAs9zsAiumPPrc3i5TbvdYWROOULFCR+CSAvphKMuEefnYiAMJGrVgQ15D04ww9qCvmCI5oySv1xsDI0FRVVA6NlBD2rx1F5XPX9i66ga9o0UUgQwc4wgctowxgePvPvPgvFW+UQ5IjwQtUwVoV0AuULBl4qsGLdkUtHjhSyTYytoFDhV8tnwscwYzGhCaSVCOni30o2d1A3xV8=
   on:
     tags: true
     branch: master
+- provider: script
+  script: /bin/sh .travis/deploy_linux.sh
+  on:
+    branch: master
+    tags: true
+
 notifications:
   slack:
     rooms:

--- a/.travis/deploy_linux.sh
+++ b/.travis/deploy_linux.sh
@@ -1,0 +1,10 @@
+echo [distutils]                                  > ~/.pypirc
+echo index-servers =                             >> ~/.pypirc
+echo "  pypi"                                    >> ~/.pypirc
+echo                                             >> ~/.pypirc
+echo [pypi]                                      >> ~/.pypirc
+echo repository=https://upload.pypi.org/legacy/  >> ~/.pypirc
+echo username=leonardt                           >> ~/.pypirc
+echo password=$PYPI_PASSWORD                     >> ~/.pypirc
+docker cp ~/.pypirc manylinux:/home/
+docker exec -i manylinux bash -c 'cd  /pycoreir && twine upload --config-file /home/.pypirc wheelhouse/*'


### PR DESCRIPTION
Add a new provider as script to upload the manylinux wheel to pypi. It should not interfere the usual Travis-CI provided deploy.

You need to add your pypi password as `PYPI_PASSWORD` in travis.