### PR TITLE
Add support for parallel build on MacOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import glob
 import shutil
 import sys
 import platform
+import psutil
 
 
 _system = platform.system()
@@ -23,7 +24,11 @@ else:
 if os.environ.get('TRAVIS') == 'true':
     njobs = 2
 else:
-    njobs = max(2, len(os.sched_getaffinity(0)))
+    try:
+        cpus = len(psutil.Process().cpu_affinity())
+    except AttributeError:
+        cpus = psutil.cpu_count()
+    njobs = max(2, cpus)
 
 COREIR_PATH = "coreir-cpp"
 COREIR_REPO = "https://github.com/rdaly525/coreir"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import glob
 import shutil
 import sys
 import platform
-import psutil
+import multiprocessing
 
 
 _system = platform.system()
@@ -25,9 +25,9 @@ if os.environ.get('TRAVIS') == 'true':
     njobs = 2
 else:
     try:
-        cpus = len(psutil.Process().cpu_affinity())
+        cpus = len(os.sched_getaffinity(0))
     except AttributeError:
-        cpus = psutil.cpu_count()
+        cpus = multiprocessing.cpu_count()
     njobs = max(2, cpus)
 
 COREIR_PATH = "coreir-cpp"


### PR DESCRIPTION
This isn't caught by the Travis CI because it's guarded by the TRAVIS
environment variable being set, but it seems that `sched_getaffinity` is
not available on my MacOS system:

    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/leonardtruong/repos/pycoreir/setup.py", line 27, in <module>
        njobs = max(2, len(os.sched_getaffinity(0)))
    AttributeError: module 'os' has no attribute 'sched_getaffinity'