### PR TITLE
Fix parameter passing in bin/coreir

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     docker exec garnet-flow pip install magma-lang  # For libcoreir-python test
-    docker exec garnet-flow pytest -s /pycoreir/tests/
+    docker exec garnet-flow cd /pycoreir && pytest -s tests/
 else
     # osx
     pip install magma-lang

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     docker exec garnet-flow pip install magma-lang  # For libcoreir-python test
-    docker exec garnet-flow cd /pycoreir && pytest -s tests/
+    docker exec garnet-flow bash -c "cd /pycoreir && pytest -s tests/"
 else
     # osx
     pip install magma-lang

--- a/bin/coreir
+++ b/bin/coreir
@@ -4,6 +4,7 @@ import platform
 import sys
 import os
 import coreir
+import subprocess
 
 
 _system = platform.system()
@@ -16,5 +17,6 @@ else:
 
 path = os.path.abspath(os.path.dirname(coreir.__file__))
 coreir_binary = os.path.join(path, "coreir")
-args = " ".join(sys.argv[1:])
-os.system(f"{LIBRARY_PATH_VAR}={path}:${LIBRARY_PATH_VAR} {coreir_binary} {args}")
+env = dict(os.environ)
+env[LIBRARY_PATH_VAR] = path
+subprocess.call([coreir_binary] + sys.argv[1:], env=env)

--- a/tests/concat.json
+++ b/tests/concat.json
@@ -1,0 +1,38 @@
+{
+  "top": "global.concats",
+  "namespaces": {
+    "global": {
+      "modules": {
+        "concats": {
+          "type": ["Record",[
+            ["in", ["Array",16,"BitIn"]],
+            ["out", ["Array",16,"Bit"]]
+          ]],
+          "instances": {
+            "s0": {
+              "genref": "coreir.slice",
+              "genargs": {"width":["Int", 16], "hi":["Int",16], "lo":["Int",12]}
+            },
+            "s1": {
+              "genref": "coreir.slice",
+              "genargs": {"width":["Int", 16], "hi":["Int",15], "lo":["Int",3]}
+            },
+            "cc0": {
+              "genref": "coreir.concat",
+              "genargs": {"width0":["Int", 4],"width1":["Int", 12]}
+            }
+          },
+          "connections": [
+            ["self.in","s0.in"],
+            ["self.in","s1.in"],
+            ["s0.out","cc0.in0"],
+            ["s1.out","cc0.in1"],
+            ["cc0.out","self.out"]
+          ]
+        }
+      }
+    }
+  }
+}
+
+

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1,0 +1,11 @@
+import os
+import subprocess
+
+
+def test_bin():
+    result = subprocess.run(
+        "python bin/coreir -i tests/concat.json -p 'rungenerators; flatten'",
+        shell=True, capture_output=True)
+    assert not result.returncode, \
+        "Got non-zero exit code ({result.returncode}): " + \
+        result.stdout.decode() + result.stderr.decode()


### PR DESCRIPTION
Fixes https://github.com/leonardt/pycoreir/issues/100

The issue was that the parameters passed to the python script were not
being properly escaped when passed through to the shell command that
invokes the coreir binary. This uses the subprocess interface which
handles the escaping implicitly (and is a much safer/robust
implementation).