### PR TITLE
Adding native wheel back again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,46 @@
+services:
+    - docker
+
 matrix:
   include:
   - os: linux
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-7
-        - libgmp-dev
-        - libmpfr-dev
-        - libmpc-dev
-    env:
-    - CC=gcc-7
-    - CXX=g++-7
   - os: osx
     osx_image: xcode10.2
 before_install:
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
-  else
-    # install conda for py 3.7
-    wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+    chmod +x miniconda.sh
+    ./miniconda.sh -b -p $TRAVIS_BUILD_DIR/miniconda
+    export PATH=$TRAVIS_BUILD_DIR/miniconda/bin:$PATH
+    hash -r
+    conda config --set always_yes yes --set changeps1 no
+    conda update -q conda
+    conda create -q -n test-env python=3.7.3
+    source activate test-env
+    conda install pip
   fi
-- chmod +x miniconda.sh
-- ./miniconda.sh -b -p $TRAVIS_BUILD_DIR/miniconda
-- export PATH=$TRAVIS_BUILD_DIR/miniconda/bin:$PATH
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda create -q -n test-env python=3.7.3
-- source activate test-env
-- conda install pip
 install:
 - echo $TRAVIS_BRANCH
 - echo $TRAVIS_OS_NAME
 - echo $TRAVIS_BUILD_DIR
-- source .travis/install_coreir.sh
-- coreir  # test command
-- pip install -e .
-- pip install pytest magma-lang
+- |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      source .travis/install_coreir.sh
+      coreir  # test command
+      pip install -e .
+      pip install pytest magma-lang
+    else
+      source ./.travis/setup.sh
+    fi
+
 script:
-- pytest -s tests/
+- |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      pytest -s tests/
+    else
+      source ./.travis/run.sh
+    fi
 deploy:
   provider: pypi
   user: leonardt

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,23 +24,10 @@ install:
 - echo $TRAVIS_BRANCH
 - echo $TRAVIS_OS_NAME
 - echo $TRAVIS_BUILD_DIR
-- |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      source .travis/install_coreir.sh
-      coreir  # test command
-      pip install -e .
-      pip install pytest magma-lang
-    else
-      source ./.travis/setup.sh
-    fi
+- source ./.travis/setup.sh
 
 script:
-- |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      pytest -s tests/
-    else
-      source ./.travis/run.sh
-    fi
+- source ./.travis/run.sh
 deploy:
   provider: pypi
   user: leonardt

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_install:
     conda create -q -n test-env python=3.7.3
     source activate test-env
     conda install pip
+    # see https://github.com/Z3Prover/z3/issues/2800
+    pip install https://github.com/Z3Prover/z3/releases/download/Nightly/z3_solver-4.8.8.0-py2.py3-none-macosx_10_14_x86_64.whl
   fi
 install:
 - echo $TRAVIS_BRANCH

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    docker pull keyiz/manylinux-coreir
+    docker pull keyiz/manylinux
     docker pull keyiz/garnet-flow
-    docker run -d --name manylinux --rm -it --mount type=bind,source="$(pwd)"/../pycoreir,target=/pycoreir keyiz/manylinux-coreir bash
+    docker run -d --name manylinux --rm -it --mount type=bind,source="$(pwd)"/../pycoreir,target=/pycoreir keyiz/manylinux bash
     docker run -d --name garnet-flow --rm -it --mount type=bind,source="$(pwd)"/../pycoreir,target=/pycoreir keyiz/garnet-flow bash
     docker cp ../pycoreir manylinux:/
     docker exec manylinux bash -c "cd pycoreir && python setup.py bdist_wheel"
     docker exec manylinux bash -c "pip install auditwheel"
     docker exec manylinux bash -c "auditwheel show /pycoreir/dist/*.whl"
     # we should have any external linked libraries at this point
-    docker exec manylinux bash -c "cd pycoreir && auditwheel repair dist/*.whl"
+    docker exec manylinux bash -c "cd pycoreir && LD_LIBRARY_PATH=/pycoreir/coreir-cpp/build/lib  auditwheel repair dist/*.whl"
     # install the wheel for testing
     # use garnetflow container to test since it has all the prereqs
     docker exec garnet-flow bash -c "cd pycoreir && pip install wheelhouse/*.whl"

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -10,22 +10,13 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     docker exec manylinux bash -c "pip install auditwheel"
     docker exec manylinux bash -c "auditwheel show /pycoreir/dist/*.whl"
     # we should have any external linked libraries at this point
-    docker exec manylinux bash -c "cd pycoreir && LD_LIBRARY_PATH=/pycoreir/coreir-cpp/build/lib:$LD_LIRBARY_PATH auditwheel repair dist/*.whl"
+    docker exec manylinux bash -c "cd pycoreir && LD_LIBRARY_PATH=/pycoreir/coreir-cpp/build/lib:/opt/rh/devtoolset-2/root/usr/lib64:/opt/rh/devtoolset-2/root/usr/lib:/usr/local/lib64:/usr/local/lib auditwheel repair dist/*.whl"
     # install the wheel for testing
     # use garnetflow container to test since it has all the prereqs
     docker exec garnet-flow bash -c "cd pycoreir && pip install wheelhouse/*.whl"
     docker exec garnet-flow pip install pytest
 else
-     export PYTHON=3.7.0
-     brew install gmp mpfr libmpc
-     brew install pyenv-virtualenv
-     pyenv install ${PYTHON}
-     export PYENV_VERSION=$PYTHON
-     export PATH="/Users/travis/.pyenv/shims:${PATH}"
-     pyenv virtualenv venv
-     source /Users/travis/.pyenv/versions/${PYTHON}/envs/venv/bin/activate
      python --version
-
      python -m pip install cmake twine wheel pytest
      python setup.py bdist_wheel
      pip install dist/*.whl

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -10,7 +10,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     docker exec manylinux bash -c "pip install auditwheel"
     docker exec manylinux bash -c "auditwheel show /pycoreir/dist/*.whl"
     # we should have any external linked libraries at this point
-    docker exec manylinux bash -c "cd pycoreir && LD_LIBRARY_PATH=/pycoreir/coreir-cpp/build/lib  auditwheel repair dist/*.whl"
+    docker exec manylinux bash -c "cd pycoreir && LD_LIBRARY_PATH=/pycoreir/coreir-cpp/build/lib:$LD_LIRBARY_PATH auditwheel repair dist/*.whl"
     # install the wheel for testing
     # use garnetflow container to test since it has all the prereqs
     docker exec garnet-flow bash -c "cd pycoreir && pip install wheelhouse/*.whl"

--- a/coreir/lib.py
+++ b/coreir/lib.py
@@ -11,12 +11,12 @@ def load_shared_lib(lib):
         shared_lib_ext = "dylib"
     else:
         raise NotImplementedError(_system)
-    # libpath = os.path.join(os.path.dirname(os.path.abspath(__file__)), lib)
-    # libpath = "{}.{}".format(libpath, shared_lib_ext)
-    # if not os.path.isfile(libpath):
-    #     # fall back to system lib
-    #     libpath = "{}.{}".format(lib, shared_lib_ext)
-    libpath = "{}.{}".format(lib, shared_lib_ext)
+    libpath = os.path.join(os.path.dirname(os.path.abspath(__file__)), lib)
+    libpath = "{}.{}".format(libpath, shared_lib_ext)
+    if not os.path.isfile(libpath):
+        # fall back to system lib
+        libpath = "{}.{}".format(lib, shared_lib_ext)
+    # libpath = "{}.{}".format(lib, shared_lib_ext)
     return cdll.LoadLibrary(libpath)
 
 

--- a/coreir/lib.py
+++ b/coreir/lib.py
@@ -16,7 +16,6 @@ def load_shared_lib(lib):
     if not os.path.isfile(libpath):
         # fall back to system lib
         libpath = "{}.{}".format(lib, shared_lib_ext)
-    # libpath = "{}.{}".format(lib, shared_lib_ext)
     return cdll.LoadLibrary(libpath)
 
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ class CoreIRBuild(build_ext):
             # we're done here since users provide their own coreir distribution
             return
         if not os.path.isdir(COREIR_PATH):
-            subprocess.check_call(["git", "clone", "--depth=1", "--branch=hotfix-verilogast-update", COREIR_REPO,
+            subprocess.check_call(["git", "clone", "--depth=1", COREIR_REPO,
                                    COREIR_PATH])
         build_dir = os.path.join(COREIR_PATH, "build")
         if static_build:

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,16 @@ class CoreIRBuild(build_ext):
         textchars = bytearray({7,8,9,10,12,13,27} | set(range(0x20, 0x100)) - {0x7f})
         is_binary_string = lambda bytes: bool(bytes.translate(None, textchars))
         with open(path) as f:
-            return is_binary_string(f.read(1024))
+            try:
+                return is_binary_string(f.read(1024))
+            except UnicodeDecodeError:
+                # assume binary
+                return True
 
     def run(self):
         # skip if coreir binary is found. this is useful if people want
         # to use their own version of coreir
-        # notice that if this may cause a problem if they are building this
+        # notice that this may cause a problem if they are building this
         # from scratch multiple times as the coreir will be in the path
         coreir_path = shutil.which("coreir")
         if coreir_path is not None and self.is_binary(coreir_path):

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ class CoreIRBuild(build_ext):
             "coreir-float_CW", "coreir-float_DW", "verilogAST"]
     def run(self):
         if not os.path.isdir(COREIR_PATH):
-            subprocess.check_call(["git", "clone", "--depth=1", COREIR_REPO,
+            subprocess.check_call(["git", "clone", "--depth=1", "--branch=hotfix-verilogast-update", COREIR_REPO,
                                    COREIR_PATH])
         build_dir = os.path.join(COREIR_PATH, "build")
         if static_build:

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,9 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=["hwtypes>=1.0.*"],
+    ext_modules=[CoreIRExtension('coreir')],
+    scripts=["bin/coreir"],
+    cmdclass=dict(build_ext=CoreIRBuild),
     zip_safe=False
     # **kwargs
 )

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,24 @@ class CoreIRBuild(build_ext):
     libs = ["coreir-c", "coreirsim-c", "coreir-ice40", "coreir-aetherlinglib",
             "coreir-commonlib", "coreir-float", "coreir-rtlil",
             "coreir-float_CW", "coreir-float_DW", "verilogAST"]
+
+    @staticmethod
+    def is_binary(path):
+        # adapted from https://stackoverflow.com/a/7392391
+        textchars = bytearray({7,8,9,10,12,13,27} | set(range(0x20, 0x100)) - {0x7f})
+        is_binary_string = lambda bytes: bool(bytes.translate(None, textchars))
+        with open(path) as f:
+            return is_binary_string(f.read(1024))
+
     def run(self):
+        # skip if coreir binary is found. this is useful if people want
+        # to use their own version of coreir
+        # notice that if this may cause a problem if they are building this
+        # from scratch multiple times as the coreir will be in the path
+        coreir_path = shutil.which("coreir")
+        if coreir_path is not None and self.is_binary(coreir_path):
+            # we're done here since users provide their own coreir distribution
+            return
         if not os.path.isdir(COREIR_PATH):
             subprocess.check_call(["git", "clone", "--depth=1", "--branch=hotfix-verilogast-update", COREIR_REPO,
                                    COREIR_PATH])


### PR DESCRIPTION
What does this PR do:
- Adding native wheels back to coreir
- Improve the build process that if a coreir binary already exists in `PATH`, skip the build process and use the default one. This allows people to test their own coreir. I haven't tested it though.

What needs to be done:
- I don't have access to the travis setting, so we need to revert to the old deployment script at some point.
- Test on build skipping as mentioned above.

Some tricks I used to speed up macos build (about 4x):
- A pre-built z3-solver wheel is used. See: https://github.com/Z3Prover/z3/issues/2800
- It seems like miniconda is faster than brew.