### PR TITLE
Fix macOS install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,11 @@ import multiprocessing
 
 _system = platform.system()
 if _system == "Linux":
+    extra_libs = []
     lib_ext = "so"
     static_build = True
 elif _system == "Darwin":
+    extra_libs = ["coreir", "coreirsim"]
     lib_ext = "dylib"
     # osx default xcode doesn't support static build
     static_build = False
@@ -66,7 +68,7 @@ class CoreIRExtension(Extension):
 class CoreIRBuild(build_ext):
     libs = ["coreir-c", "coreirsim-c", "coreir-ice40", "coreir-aetherlinglib",
             "coreir-commonlib", "coreir-float", "coreir-rtlil",
-            "coreir-float_CW", "coreir-float_DW", "verilogAST"]
+            "coreir-float_CW", "coreir-float_DW", "verilogAST"] + extra_libs
 
     def run(self):
         # skip if coreir binary is found. this is useful if people want


### PR DESCRIPTION
macOS requires extra two libraries from coreir. libcoreir.dylib and libcoreirsim.dylib

    $ pip3 install .
    $ coreir
    Traceback (most recent call last):
      File "/usr/local/bin/coreir", line 10, in <module>
        import coreir
      File "/usr/local/lib/python3.7/site-packages/coreir/__init__.py", line 5, in <module>
        from coreir.global_value import COREGlobalValue_p
      File "/usr/local/lib/python3.7/site-packages/coreir/global_value.py", line 1, in <module>
        from .base import CoreIRType
      File "/usr/local/lib/python3.7/site-packages/coreir/base.py", line 2, in <module>
        from .lib import libcoreir_c
      File "/usr/local/lib/python3.7/site-packages/coreir/lib.py", line 74, in <module>
        libcoreir_c = load_coreir_lib("c")
      File "/usr/local/lib/python3.7/site-packages/coreir/lib.py", line 71, in load_coreir_lib
        return load_shared_lib('libcoreir-{}'.format(suffix))
      File "/usr/local/lib/python3.7/site-packages/coreir/lib.py", line 67, in load_shared_lib
        return cdll.LoadLibrary(lib_path)
      File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ctypes/__init__.py", line 442, in LoadLibrary
        return self._dlltype(name)
      File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ctypes/__init__.py", line 364, in __init__
        self._handle = _dlopen(self._name, mode)
    OSError: dlopen(/usr/local/lib/python3.7/site-packages/coreir/libcoreir-c.dylib, 6): Library not loaded: @rpath/libcoreir.dylib
      Referenced from: /usr/local/lib/python3.7/site-packages/coreir/libcoreir-c.dylib
      Reason: image not found