### PR TITLE
Fixes

### DIFF
--- a/coreir/type.py
+++ b/coreir/type.py
@@ -61,7 +61,7 @@ class Value(CoreIRType):
             else:
                 width = ct.c_int()
                 libcoreir_c.COREValueBitVectorGetWidth(self.ptr, ct.byref(width))
-                return BitVector[width.value](None)
+                return BitVector[width.value](0)
         elif type == 3:
             return libcoreir_c.COREValueStringGet(self.ptr).decode()
         elif type == 6:

--- a/coreir/wireable.py
+++ b/coreir/wireable.py
@@ -28,7 +28,7 @@ class Wireable(CoreIRType):
 
     def select(self, field):
         if not libcoreir_c.COREWireableCanSelect(self.ptr,str.encode(field)):
-            raise Exception("Cannot Select this Wireable with " + field)
+            raise Exception(f"Cannot Select {self.selectpath} with {field}")
         return Select(libcoreir_c.COREWireableSelect(self.ptr, str.encode(field)),self.context)
 
     @property


### PR DESCRIPTION
Better error
Defaults 'x' bitvector construction to 0 (instead of the failing None)