### PR TITLE
Enable revision test

### DIFF
--- a/tests/test_coreir.py
+++ b/tests/test_coreir.py
@@ -210,11 +210,10 @@ def test_context():
 def test_version():
     context = coreir.Context()
     version = context.get_version()
-    # TODO: get_revision seems to return empty string on latest coreir master
-    # revision = context.get_revision()
+    revision = context.get_revision()
     assert isinstance(version, str) and len(version) > 0
-    # assert isinstance(revision, str) and len(revision) > 0
-    # print("version:", version, revision)
+    assert isinstance(revision, str) and len(revision) > 0
+    print("version:", version, revision)
 
 if __name__ == "__main__":
     test_module_def_instances()


### PR DESCRIPTION
This reverts commit a8c9264506ab4fbc7426531f0b380ef9b448c6d7.

It seems that this feature was broken by an upstream change in coreir, perhaps https://github.com/rdaly525/coreir/pull/917/files? (CC @splhack)