### PR TITLE
Use check_call to avoid silent errors

### DIFF
--- a/bin/coreir
+++ b/bin/coreir
@@ -16,7 +16,7 @@ if COREIR_BINARY_PATH is None:
     # Assume we did a static build and use the corresponding binary
     path = os.path.abspath(os.path.dirname(coreir.__file__))
     coreir_binary = os.path.join(path, "coreir")
-    subprocess.call([coreir_binary] + sys.argv[1:])
+    subprocess.check_call([coreir_binary] + sys.argv[1:])
 else:
     # Found existing binary in path, use this
-    subprocess.call([COREIR_BINARY_PATH] + sys.argv[1:])
+    subprocess.check_call([COREIR_BINARY_PATH] + sys.argv[1:])


### PR DESCRIPTION
Switches the binary wrapper script to use check_call so errors invoking
coreir in the subprocess don't fail silently (raises an exception in
stead).  See https://docs.python.org/3/library/subprocess.html#subprocess.check_call