### PR TITLE
adds assertion to check for deleted contexts

### DIFF
--- a/coreir/context.py
+++ b/coreir/context.py
@@ -48,6 +48,8 @@ _library_cache = {}
 
 def namespace_cache(f):
     def method(self, name: str):
+        if self.context is None:
+            raise ValueError("Cannot use deleted context!")
         c_addr = ct.addressof(self.context)
         if name in _library_cache[c_addr]:
             return _library_cache[c_addr][name]
@@ -263,6 +265,7 @@ class Context:
         None check for all the API code, instead we assume if this is used that
         the user is certain that the context object will no longer be used.
         """
+        print("DELETING", self)
         if self.context is None:
             raise Exception("Context already deleted")
         c_addr = ct.addressof(self.context)


### PR DESCRIPTION
This can occur if context.delete is called, then the context is used again. 