### PR TITLE
Update "which" logic to avoid dumping to stderr

### DIFF
--- a/coreir/lib.py
+++ b/coreir/lib.py
@@ -1,6 +1,7 @@
 from ctypes import cdll
 import platform
 import os
+import subprocess
 
 
 def is_binary(path):
@@ -17,8 +18,10 @@ def is_binary(path):
 
 # see if a coreir binary exists in the user's path
 COREIR_BINARY_PATH = None
-with os.popen("which -a coreir") as process:
-    for line in process.read().splitlines():
+with subprocess.Popen(["which", "-a", "coreir"],
+                      stdout=subprocess.PIPE,
+                      stderr=subprocess.DEVNULL) as process:
+    for line in process.stdout.read().splitlines():
         if is_binary(line):
             COREIR_BINARY_PATH = line
             break

--- a/coreir/lib.py
+++ b/coreir/lib.py
@@ -2,6 +2,7 @@ from ctypes import cdll
 import platform
 import os
 import subprocess
+import sys
 
 
 def is_binary(path):
@@ -23,7 +24,7 @@ with subprocess.Popen(["which", "-a", "coreir"],
                       stderr=subprocess.DEVNULL) as process:
     for line in process.stdout.read().splitlines():
         if is_binary(line):
-            COREIR_BINARY_PATH = line
+            COREIR_BINARY_PATH = line.decode(sys.stdout.encoding)
             break
 
 SYSTEM = platform.system()
@@ -52,7 +53,7 @@ def get_lib_dir():
     # There's a binary on $PATH. Use the corresponding libraries (which we
     # assume to be at ../lib relative to it)
     bin_dir = os.path.dirname(COREIR_BINARY_PATH)
-    lib_dir = os.path.normpath(os.path.join(bin_dir, b'../lib'))
+    lib_dir = os.path.normpath(os.path.join(bin_dir, '../lib'))
 
     if not os.path.isdir(lib_dir):
         raise RuntimeError('We found a coreir binary at {}, but there\'s no '

--- a/coreir/lib.py
+++ b/coreir/lib.py
@@ -21,7 +21,7 @@ COREIR_BINARY_PATH = None
 with subprocess.Popen(["which", "-a", "coreir"],
                       stdout=subprocess.PIPE,
                       stderr=subprocess.DEVNULL) as process:
-    for line in process.stdout.read().splitlines():
+    for line in process.stdout.splitlines():
         if is_binary(line):
             COREIR_BINARY_PATH = line
             break

--- a/coreir/lib.py
+++ b/coreir/lib.py
@@ -23,7 +23,7 @@ with subprocess.Popen(["which", "-a", "coreir"],
                       stderr=subprocess.DEVNULL) as process:
     for line in process.stdout.read().splitlines():
         if is_binary(line):
-            COREIR_BINARY_PATH = str(line)
+            COREIR_BINARY_PATH = line
             break
 
 SYSTEM = platform.system()
@@ -52,7 +52,7 @@ def get_lib_dir():
     # There's a binary on $PATH. Use the corresponding libraries (which we
     # assume to be at ../lib relative to it)
     bin_dir = os.path.dirname(COREIR_BINARY_PATH)
-    lib_dir = os.path.normpath(os.path.join(bin_dir, '../lib'))
+    lib_dir = os.path.normpath(os.path.join(bin_dir, b'../lib'))
 
     if not os.path.isdir(lib_dir):
         raise RuntimeError('We found a coreir binary at {}, but there\'s no '

--- a/coreir/lib.py
+++ b/coreir/lib.py
@@ -23,7 +23,7 @@ with subprocess.Popen(["which", "-a", "coreir"],
                       stderr=subprocess.DEVNULL) as process:
     for line in process.stdout.read().splitlines():
         if is_binary(line):
-            COREIR_BINARY_PATH = line
+            COREIR_BINARY_PATH = str(line)
             break
 
 SYSTEM = platform.system()

--- a/coreir/lib.py
+++ b/coreir/lib.py
@@ -21,7 +21,7 @@ COREIR_BINARY_PATH = None
 with subprocess.Popen(["which", "-a", "coreir"],
                       stdout=subprocess.PIPE,
                       stderr=subprocess.DEVNULL) as process:
-    for line in process.stdout.splitlines():
+    for line in process.stdout.read().splitlines():
         if is_binary(line):
             COREIR_BINARY_PATH = line
             break


### PR DESCRIPTION
Before, stderr would dump by default to stderr which would cause a
"false" error to be reported to the user's terminal.

This also moves from os.popen to subprocess.Popen to keep up with the
latest Python convention